### PR TITLE
core: remove deprecated gulp-util dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 // through2 is a thin wrapper around node transform streams
 var through = require('through2');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var stripBanner = require('strip-banner');
-var PluginError = gutil.PluginError;
 
 // consts
 const PLUGIN_NAME = 'gulp-strip-banner';

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^1.21.4",
-    "should": "^4.0.4",
+    "mocha": "^5.0.0",
+    "should": "^13.2.1",
     "vinyl": "^2.1.0"
   },
   "dependencies": {
-    "plugin-error": "^0.1.2",
+    "plugin-error": "^1.0.0",
     "strip-banner": "^0.2.0",
     "through2": "^2.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "gulp-util": "^3.0.1",
     "mocha": "^1.21.4",
-    "should": "^4.0.4"
+    "should": "^4.0.4",
+    "vinyl": "^2.1.0"
   },
   "dependencies": {
-    "gulp-util": "^3.0.1",
+    "plugin-error": "^0.1.2",
     "strip-banner": "^0.2.0",
-    "through2": "^0.6.1"
+    "through2": "^2.0.3"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -4,14 +4,14 @@
 
 var strip_banner = require('../');
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 require('mocha');
 
 describe('strip_banner', function(){
   var fakeFile;
 
   function getFakeFile(fileContent){
-    return new gutil.File({
+    return new Vinyl({
       path: './test/fixture/test.js',
       cwd: './test/',
       base: './test/fixture/',


### PR DESCRIPTION
Hi,
The `gulp-util` dependency has been deprecated. This commit replace it with individual submodules, as suggested [here](https://github.com/gulpjs/gulp-util).